### PR TITLE
Fix code signing errors + add option to build RPM without apache config.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,8 +31,20 @@ srpm: prepare ## Build a source rpm
 	echo -e "Package saved to: \e[31m`ls SRPMS/$(NAME)-$(VERSION)*.src.rpm`\e[0m"
 	$(DONE)
 
+minimalsrpm: prepare ## Build a source rpm
+	mock --buildsrpm --spec=$(CWD)/SPECS/$(NAME).spec --sources=$(CWD)/SOURCES/ --resultdir=$(CWD)/SRPMS --define "__version $(VERSION)" --define "__release $(BUILD_NUMBER)" --rpmbuild-opts "--without apache"
+	rm -rf SRPMS/*.log
+	echo -e "Package saved to: \e[31m`ls SRPMS/$(NAME)-$(VERSION)*.src.rpm`\e[0m"
+	$(DONE)
+
 rpm: srpm ## Build an rpm from the sourcerpm
 	mock --rebuild $(CWD)/SRPMS/$(NAME)*.src.rpm --resultdir=$(CWD)/RPMS/ --define "__version $(VERSION)" --define "__release $(BUILD_NUMBER)"
+	cp RPMS/$(NAME)-$(VERSION)*.noarch.rpm pkg/
+	echo -e "Package saved to: \e[31m`ls RPMS/$(NAME)-$(VERSION)*.noarch.rpm`\e[0m"
+	$(DONE)
+
+minimalrpm: minimalsrpm ## Build an rpm from the sourcerpm
+	mock --rebuild $(CWD)/SRPMS/$(NAME)*.src.rpm --resultdir=$(CWD)/RPMS/ --define "__version $(VERSION)" --define "__release $(BUILD_NUMBER)" --rpmbuild-opts "--without apache"
 	cp RPMS/$(NAME)-$(VERSION)*.noarch.rpm pkg/
 	echo -e "Package saved to: \e[31m`ls RPMS/$(NAME)-$(VERSION)*.noarch.rpm`\e[0m"
 	$(DONE)


### PR DESCRIPTION
Hi

This PR should fix the code signing errors by removing the code that removes some dot files and edits signature.json. 

I also added an option to build a RPM which won't add an Apache vhost config, this can be useful when creating the vhost manually or using Puppet etc.